### PR TITLE
zynqmp-arm.dtsi: Improve RPU interrupt controller

### DIFF
--- a/zynqmp-arm.dtsi
+++ b/zynqmp-arm.dtsi
@@ -556,11 +556,33 @@ glue(glue(glue(tcm_mem_ctrl_, n), _), AB): glue(glue(tcm_mem_ctrl_, AB), n)@n {	
 			interrupts-extended =
 #ifdef MULTI_ARCH
 				<&rpu_intc_redirect_0 0>,
-				<&rpu_intc_redirect_1 0>;
+				<&rpu_intc_redirect_1 0>,
 #else
 				<&rpu_cpu0 0>,
-				<&rpu_cpu1 0>;
+				<&rpu_cpu1 0>,
 #endif
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+				<&dummy 0>,
+#ifdef MULTI_ARCH
+				<&rpu_intc_redirect_0 1>,
+				<&rpu_intc_redirect_1 1>;
+#else
+				<&rpu_cpu0 1>,
+				<&rpu_cpu1 1>;
+#endif
+			has-security-extensions = <1>;
 		};
 	};
 


### PR DESCRIPTION
Add FIQ support for RPU.

Enable the GIC Security Extensions.  The GIC configuration of the RPU is a bit odd.  It supports the Security Extensions, however, only the Secure state is implemented.  This configuration allows to use FIQs for group 0 interrupts.